### PR TITLE
Fix SP Lambda and log permissions

### DIFF
--- a/monitor_sps_and_ris.py
+++ b/monitor_sps_and_ris.py
@@ -80,6 +80,8 @@ def lambda_handler(event, context):
     # Iterate over Redshift Reserved Nodes
     redshift_nodes = redshift_client.describe_reserved_nodes()
     for node in redshift_nodes['ReservedNodes']:
+        if 'EndTime' not in node:
+            continue
         expiration_date = node['EndTime']
         days_until_expiration = (expiration_date - now).days
 

--- a/monitor_sps_and_ris.tf
+++ b/monitor_sps_and_ris.tf
@@ -31,7 +31,7 @@ data "aws_iam_policy_document" "monitor_sps_and_ris_execution" {
 
   statement {
     effect    = "Allow"
-    resources = ["arn:aws:logs:${local.region}:${local.account_id}:log-group:/aws/lambda/monitor_sps_and_ris_execution:*"]
+    resources = ["arn:aws:logs:${local.region}:${local.account_id}:log-group:/aws/lambda/${var.name_prefix}monitor_sps_and_ris_execution:*"]
 
     actions = [
       "logs:CreateLogGroup",


### PR DESCRIPTION
- Fixes a bug in the Savings Plan monitoring Lambda that occurs when Redshift is preset
- Fixes IAM permissions for the Savings Plan monitoring lambda that was preventing it from logging when a `name_prefix`w was specified.
